### PR TITLE
fixed durable mode exception object limitation of serilog compact log…

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ var log = new LoggerConfiguration()
     .CreateLogger();
 ```
 
+Note: Inorder to get the exception as string mapped to kusto column such as Exception, it is recommended to use ExceptionString Attribute.
+For example:
+```csharp
+new SinkColumnMapping { ColumnName ="Exception", ColumnType ="string", ValuePath = "$.ExceptionString" }
+```
+
 ## Features
 
 * Supports both Queued and Streaming ingestion

--- a/src/Serilog.Sinks.AzureDataExplorer/Extensions/LogEventExtensions.cs
+++ b/src/Serilog.Sinks.AzureDataExplorer/Extensions/LogEventExtensions.cs
@@ -46,7 +46,7 @@ namespace Serilog.Sinks.AzureDataExplorer.Extensions
             LogEvent logEvent,
             IFormatProvider formatProvider = null)
         {
-            var eventObject = new Dictionary<string, object>(5);
+            var eventObject = new Dictionary<string, object>(6);
 
             eventObject.Add("Timestamp", logEvent.Timestamp.ToUniversalTime().ToString("o"));
 
@@ -54,6 +54,7 @@ namespace Serilog.Sinks.AzureDataExplorer.Extensions
             eventObject.Add("Level", logEvent.Level.ToString());
             eventObject.Add("Message", logEvent.RenderMessage(formatProvider));
             eventObject.Add("Exception", logEvent.Exception);
+            eventObject.Add("ExceptionString", logEvent.Exception?.ToString() ?? "");
             eventObject.Add("Properties", logEvent.Properties.Dictionary());
 
             return eventObject;

--- a/src/Serilog.Sinks.AzureDataExplorer/Serilog.Sinks.AzureDataExplorer.csproj
+++ b/src/Serilog.Sinks.AzureDataExplorer/Serilog.Sinks.AzureDataExplorer.csproj
@@ -22,9 +22,9 @@ Improved options default values
     </PackageReleaseNotes>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <SignAssembly>True</SignAssembly>
-    <Version>1.0.2</Version>
-    <AssemblyVersion>1.0.2.0</AssemblyVersion>
-    <FileVersion>1.0.2.0</FileVersion>
+    <Version>1.0.3</Version>
+    <AssemblyVersion>1.0.3.0</AssemblyVersion>
+    <FileVersion>1.0.3.0</FileVersion>
   </PropertyGroup>
     
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">


### PR DESCRIPTION
Please refer to the last line of https://github.com/serilog/serilog-formatting-compact-reader
"Exceptions deserialized this way aren't instances of the original exception type - all you can do with them is call ToString() to get the formatted message and stack trace, which is what 99% of Serilog sinks will do."
We use this lib in durable mode of ADX ingestion to deserialize .clef to Serilog LogEvent object. Due to this when exception objects don't get deserialized properly.
