### PR TITLE
fixed durable mode exception object limitation of serilog compact logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,16 @@ var log = new LoggerConfiguration()
     {
         IngestionEndpointUri = "https://ingest-mycluster.northeurope.kusto.windows.net",
         DatabaseName = "MyDatabase",
-        TableName = "Serilogs"
-        BufferBaseFileName = "BufferBaseFileName"
+        TableName = "Serilogs",
+        BufferBaseFileName = "BufferBaseFileName",
+        BufferFileRollingInterval = RollingInterval.Minute
     })
     .CreateLogger();
+```
+Note: Inorder to get the exception as string mapped to kusto column such as Exception, it is recommended to use ExceptionEx Attribute.
+For example:
+```csharp
+new SinkColumnMapping { ColumnName ="Exception", ColumnType ="string", ValuePath = "$.ExceptionEx" }
 ```
 
 ## Features

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -27,11 +27,12 @@
       Added durability to the Azure Data Explorer Sink
       Added Sample project
       Added Tests
+      Added additional Exception object for durable mode
     </PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <SignAssembly>True</SignAssembly>
-    <Version>1.0.3</Version>
-    <AssemblyVersion>1.0.3.0</AssemblyVersion>
-    <FileVersion>1.0.3.0</FileVersion>
+    <Version>1.0.4</Version>
+    <AssemblyVersion>1.0.4.0</AssemblyVersion>
+    <FileVersion>1.0.4.0</FileVersion>
   </PropertyGroup>
 </Project>

--- a/src/Serilog.Sinks.AzureDataExplorer/Extensions/LogEventExtensions.cs
+++ b/src/Serilog.Sinks.AzureDataExplorer/Extensions/LogEventExtensions.cs
@@ -54,6 +54,22 @@ namespace Serilog.Sinks.AzureDataExplorer.Extensions
             eventObject.Add("Level", logEvent.Level.ToString());
             eventObject.Add("Message", logEvent.RenderMessage(formatProvider));
             eventObject.Add("Exception", logEvent.Exception);
+            if (logEvent.Exception != null)
+            {
+                var exceptionDetails = new
+                {
+                    ExceptionStr = logEvent.Exception.ToString(),
+                    Type = logEvent.Exception.GetType().FullName,
+                    Message = logEvent.Exception.Message,
+                    Source = logEvent.Exception.Source,
+                    TargetSite = logEvent.Exception.TargetSite?.Name,
+                    StackTrace = logEvent.Exception.StackTrace,
+                    HelpLink = logEvent.Exception.HelpLink,
+                    Data = logEvent.Exception.Data,
+                    InnerException = logEvent.Exception.InnerException?.ToString()
+                };
+                eventObject.Add("ExceptionEx", exceptionDetails);
+            }
             eventObject.Add("Properties", logEvent.Properties.Dictionary());
 
             return eventObject;


### PR DESCRIPTION
Please refer to the limitations section of https://github.com/serilog/serilog-formatting-compact-reader
"Exceptions deserialized this way aren't instances of the original exception type - all you can do with them is call ToString() to get the formatted message and stack trace, which is what 99% of Serilog sinks will do."
We use this lib in durable mode of ADX ingestion to deserialize .clef to Serilog LogEvent object. Due to this when exception objects don't get deserialized properly.