### PR TITLE
add .net8 framework support

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -25,9 +25,11 @@ jobs:
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}      
     - uses: actions/checkout@v2
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: |
+          6.0.x
+          8.0.x
     - name: Restore dependencies
       run: dotnet restore src
     - name: Build

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 A Serilog sink that writes events to an [Azure Data Explorer (Kusto)](https://docs.microsoft.com/en-us/azure/data-explorer) cluster.
 
 **Package** - [Serilog.Sinks.AzureDataExplorer](http://nuget.org/packages/serilog.sinks.azuredataexplorer)
-| **Platforms** - .Net 6.0
+| **Platforms** - .Net 6.0, .Net 8.0
 
 ## Getting started
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 ﻿<Project>
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <RootNamespace>Serilog.Sinks.AzureDataExplorer</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPublishable>True</IsPublishable>
@@ -22,6 +22,7 @@
     <RepositoryUrl>https://github.com/Azure/serilog-sinks-azuredataexplorer</RepositoryUrl>
     <PackageTags>serilog; serilog-sink; Azure Data Explorer; ADX; Kusto</PackageTags>
     <PackageReleaseNotes>
+      Added .NET 8.0 support with multi-targeting
       Added GZip compression when sending data
       Improved options default values
       Added durability to the Azure Data Explorer Sink
@@ -31,8 +32,8 @@
     </PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <SignAssembly>True</SignAssembly>
-    <Version>1.1.5</Version>
-    <AssemblyVersion>1.1.5.0</AssemblyVersion>
-    <FileVersion>1.1.5.0</FileVersion>
+    <Version>1.2.0</Version>
+    <AssemblyVersion>1.2.0.0</AssemblyVersion>
+    <FileVersion>1.2.0.0</FileVersion>
   </PropertyGroup>
 </Project>

--- a/src/Serilog.Sinks.AzureDataExplorer/Serilog.Sinks.AzureDataExplorer.csproj
+++ b/src/Serilog.Sinks.AzureDataExplorer/Serilog.Sinks.AzureDataExplorer.csproj
@@ -23,9 +23,9 @@
       <Pack>True</Pack>
       <PackagePath>\</PackagePath>
     </None>
-    <None Update="serilog-sink-icon.png">
+    <None Include="serilog-sink-icon.png">
       <Pack>True</Pack>
-      <PackagePath></PackagePath>
+      <PackagePath>\</PackagePath>
     </None>
   </ItemGroup>
 


### PR DESCRIPTION
This pull request adds support for .NET 8.0 to the Serilog Azure Data Explorer sink, updating the codebase and build pipeline to multi-target both .NET 6.0 and .NET 8.0. It also bumps the package version to 1.2.0 and updates documentation and release notes to reflect these changes.

**.NET 8.0 Support and Multi-targeting:**

* Updated `src/Directory.Build.props` to use `TargetFrameworks` with both `net6.0` and `net8.0` for multi-targeting.
* Updated `.github/workflows/dotnet.yml` to use `actions/setup-dotnet@v4` and install both .NET 6.0 and 8.0 SDKs.
* Updated `README.md` to list .NET 8.0 as a supported platform.
* Added release note for .NET 8.0 multi-targeting in `src/Directory.Build.props`.

**Versioning and Packaging:**

* Bumped package version to 1.2.0 in `src/Directory.Build.props` and updated assembly/file versions accordingly.
* Fixed packaging metadata for `serilog-sink-icon.png` in `Serilog.Sinks.AzureDataExplorer.csproj` to ensure correct inclusion and path.