### PR TITLE
Release 2.0.3: bump Microsoft.Azure.Kusto.Ingest to 14.1.2

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -22,6 +22,9 @@
     <RepositoryUrl>https://github.com/Azure/serilog-sinks-azuredataexplorer</RepositoryUrl>
     <PackageTags>serilog; serilog-sink; Azure Data Explorer; ADX; Kusto</PackageTags>
     <PackageReleaseNotes>
+      Version 2.0.3:
+      - Microsoft.Azure.Kusto.Ingest 14.1.0 → 14.1.2
+
       Version 2.0.2:
       - Serilog 4.3.0 → 4.3.1
       - Serilog.Sinks.Console 6.0.0 → 6.1.1
@@ -45,9 +48,9 @@
     </PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <SignAssembly>True</SignAssembly>
-    <Version>2.0.2</Version>
-    <AssemblyVersion>2.0.2.0</AssemblyVersion>
-    <FileVersion>2.0.2.0</FileVersion>
+    <Version>2.0.3</Version>
+    <AssemblyVersion>2.0.3.0</AssemblyVersion>
+    <FileVersion>2.0.3.0</FileVersion>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <Reference Include="System" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Core dependencies (used in main src) -->
-    <PackageVersion Include="Microsoft.Azure.Kusto.Ingest" Version="14.1.0" />
+    <PackageVersion Include="Microsoft.Azure.Kusto.Ingest" Version="14.1.2" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0" /> <!-- also used in tests -->
     <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.0" />

--- a/src/Serilog.Sinks.AzureDataExplorer/Extensions/AzureDataExplorerSinkOptionsExtensions.cs
+++ b/src/Serilog.Sinks.AzureDataExplorer/Extensions/AzureDataExplorerSinkOptionsExtensions.cs
@@ -21,7 +21,7 @@ namespace Serilog.Sinks.AzureDataExplorer.Extensions
     {
         private const string AppName = "Serilog.Sinks.AzureDataExplorer";
 
-        private const string ClientVersion = "2.0.2";
+        private const string ClientVersion = "2.0.3";
 
         public static KustoConnectionStringBuilder GetKustoConnectionStringBuilder(
             this AzureDataExplorerSinkOptions options)


### PR DESCRIPTION
## Release 2.0.3

Patch release that bumps the Kusto SDK to its latest patch.

### Changes
- `Microsoft.Azure.Kusto.Ingest` `14.1.0` → `14.1.2` (`src/Directory.Packages.props`)
- Version / AssemblyVersion / FileVersion `2.0.2` → `2.0.3` (`src/Directory.Build.props`)
- `ClientVersion` constant `2.0.2` → `2.0.3` (`AzureDataExplorerSinkOptionsExtensions.cs`)
- `PackageReleaseNotes` updated with 2.0.3 entry

### Validation
- `dotnet restore` ✅ (all 6 TFMs)
- `dotnet build -c Release` ✅ — 0 errors; produces `Serilog.Sinks.AzureDataExplorer.2.0.3.nupkg` + `.snupkg`
- Unit tests on net8.0: ✅ 67 / 67 passed
- E2E tests on net8.0 : ✅ 4 / 4 passed (durable, non-durable, streaming, log-level switch)

### Release
After merge, trigger the `Nuget` workflow (`.github/workflows/nuget.yml`, `workflow_dispatch`) to publish `Serilog.Sinks.AzureDataExplorer.2.0.3.nupkg` to nuget.org.