### PR TITLE
Fix #46 and #47: durable-mode cast and over-strict auth validation in convenience overload

### DIFF
--- a/src/Serilog.Sinks.AzureDataExplorer.Tests/AzureDataExplorerSinkExtensionsTests.cs
+++ b/src/Serilog.Sinks.AzureDataExplorer.Tests/AzureDataExplorerSinkExtensionsTests.cs
@@ -80,15 +80,16 @@ public class AzureDataExplorerSinkExtensionsTests
                 IngestionEndpointUri = "http://ingestionUri",
                 BufferBaseFileName = Path.Combine(bufferDir, "buffer")
             };
-            var loggerConfiguration = new LoggerConfiguration();
 
-            var sinkConfiguration = loggerConfiguration.WriteTo.AzureDataExplorerSink(options);
+            using var logger = new LoggerConfiguration()
+                .WriteTo.AzureDataExplorerSink(options)
+                .CreateLogger();
 
-            Assert.NotNull(sinkConfiguration);
+            Assert.NotNull(logger);
         }
         finally
         {
-            try { Directory.Delete(bufferDir, recursive: true); } catch { }
+            Directory.Delete(bufferDir, recursive: true);
         }
     }
 
@@ -99,22 +100,22 @@ public class AzureDataExplorerSinkExtensionsTests
         Directory.CreateDirectory(bufferDir);
         try
         {
-            var loggerConfiguration = new LoggerConfiguration();
+            using var logger = new LoggerConfiguration()
+                .WriteTo.AzureDataExplorerSink(
+                    ingestionUri: "http://ingestionUri",
+                    databaseName: "mockDB",
+                    tableName: "mockTable",
+                    applicationClientId: "clientId",
+                    applicationSecret: "secret",
+                    tenantId: "tenantId",
+                    bufferBaseFileName: Path.Combine(bufferDir, "buffer"))
+                .CreateLogger();
 
-            var sinkConfiguration = loggerConfiguration.WriteTo.AzureDataExplorerSink(
-                ingestionUri: "http://ingestionUri",
-                databaseName: "mockDB",
-                tableName: "mockTable",
-                applicationClientId: "clientId",
-                applicationSecret: "secret",
-                tenantId: "tenantId",
-                bufferBaseFileName: Path.Combine(bufferDir, "buffer"));
-
-            Assert.NotNull(sinkConfiguration);
+            Assert.NotNull(logger);
         }
         finally
         {
-            try { Directory.Delete(bufferDir, recursive: true); } catch { }
+            Directory.Delete(bufferDir, recursive: true);
         }
     }
 
@@ -233,5 +234,26 @@ public class AzureDataExplorerSinkExtensionsTests
                 tableName: "mockTable",
                 applicationClientId: null,
                 isManagedIdentity: true));
+    }
+
+    [Theory]
+    [InlineData(true, true, null)]
+    [InlineData(true, false, "some-token")]
+    [InlineData(false, true, "some-token")]
+    [InlineData(true, true, "some-token")]
+    public void AzureDataExplorerSink_Rejects_Conflicting_Auth_Modes(
+        bool isManagedIdentity, bool isWorkloadIdentity, string? userToken)
+    {
+        var loggerConfiguration = new LoggerConfiguration();
+
+        Assert.Throws<ArgumentException>(() =>
+            loggerConfiguration.WriteTo.AzureDataExplorerSink(
+                ingestionUri: "http://ingestionUri",
+                databaseName: "mockDB",
+                tableName: "mockTable",
+                applicationClientId: "clientId",
+                userToken: userToken,
+                isManagedIdentity: isManagedIdentity,
+                isWorkloadIdentity: isWorkloadIdentity));
     }
 }

--- a/src/Serilog.Sinks.AzureDataExplorer.Tests/AzureDataExplorerSinkExtensionsTests.cs
+++ b/src/Serilog.Sinks.AzureDataExplorer.Tests/AzureDataExplorerSinkExtensionsTests.cs
@@ -289,4 +289,52 @@ public class AzureDataExplorerSinkExtensionsTests
                 tableName: "mockTable",
                 userToken: userToken));
     }
+
+    [Theory]
+    [InlineData("ingestionUri", "", "mockDB", "mockTable")]
+    [InlineData("ingestionUri", " ", "mockDB", "mockTable")]
+    [InlineData("databaseName", "http://ingestionUri", "", "mockTable")]
+    [InlineData("databaseName", "http://ingestionUri", " ", "mockTable")]
+    [InlineData("tableName", "http://ingestionUri", "mockDB", "")]
+    [InlineData("tableName", "http://ingestionUri", "mockDB", " ")]
+    public void AzureDataExplorerSink_Rejects_Whitespace_Required_Strings(
+        string expectedParam, string ingestionUri, string databaseName, string tableName)
+    {
+        var loggerConfiguration = new LoggerConfiguration();
+
+        var ex = Assert.Throws<ArgumentNullException>(() =>
+            loggerConfiguration.WriteTo.AzureDataExplorerSink(
+                ingestionUri: ingestionUri,
+                databaseName: databaseName,
+                tableName: tableName,
+                applicationClientId: "clientId",
+                applicationSecret: "secret",
+                tenantId: "tenantId"));
+
+        Assert.Equal(expectedParam, ex.ParamName);
+    }
+
+    [Theory]
+    [InlineData("applicationClientId", "", "secret", "tenantId")]
+    [InlineData("applicationClientId", " ", "secret", "tenantId")]
+    [InlineData("applicationSecret", "clientId", "", "tenantId")]
+    [InlineData("applicationSecret", "clientId", " ", "tenantId")]
+    [InlineData("tenantId", "clientId", "secret", "")]
+    [InlineData("tenantId", "clientId", "secret", " ")]
+    public void AzureDataExplorerSink_AadAppKey_Rejects_Whitespace_Credentials(
+        string expectedParam, string applicationClientId, string applicationSecret, string tenantId)
+    {
+        var loggerConfiguration = new LoggerConfiguration();
+
+        var ex = Assert.Throws<ArgumentNullException>(() =>
+            loggerConfiguration.WriteTo.AzureDataExplorerSink(
+                ingestionUri: "http://ingestionUri",
+                databaseName: "mockDB",
+                tableName: "mockTable",
+                applicationClientId: applicationClientId,
+                applicationSecret: applicationSecret,
+                tenantId: tenantId));
+
+        Assert.Equal(expectedParam, ex.ParamName);
+    }
 }

--- a/src/Serilog.Sinks.AzureDataExplorer.Tests/AzureDataExplorerSinkExtensionsTests.cs
+++ b/src/Serilog.Sinks.AzureDataExplorer.Tests/AzureDataExplorerSinkExtensionsTests.cs
@@ -65,4 +65,173 @@ public class AzureDataExplorerSinkExtensionsTests
         Assert.Throws<ArgumentNullException>(() =>
             loggerConfiguration.WriteTo.AzureDataExplorerSink(options));
     }
+
+    [Fact]
+    public void AzureDataExplorerSink_DurableMode_Options_Overload_Does_Not_Throw_InvalidCast()
+    {
+        var bufferDir = Path.Combine(Path.GetTempPath(), "adxsink-test-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(bufferDir);
+        try
+        {
+            var options = new AzureDataExplorerSinkOptions
+            {
+                DatabaseName = "mockDB",
+                TableName = "mockTable",
+                IngestionEndpointUri = "http://ingestionUri",
+                BufferBaseFileName = Path.Combine(bufferDir, "buffer")
+            };
+            var loggerConfiguration = new LoggerConfiguration();
+
+            var sinkConfiguration = loggerConfiguration.WriteTo.AzureDataExplorerSink(options);
+
+            Assert.NotNull(sinkConfiguration);
+        }
+        finally
+        {
+            try { Directory.Delete(bufferDir, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void AzureDataExplorerSink_DurableMode_StringOverload_Does_Not_Throw_InvalidCast()
+    {
+        var bufferDir = Path.Combine(Path.GetTempPath(), "adxsink-test-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(bufferDir);
+        try
+        {
+            var loggerConfiguration = new LoggerConfiguration();
+
+            var sinkConfiguration = loggerConfiguration.WriteTo.AzureDataExplorerSink(
+                ingestionUri: "http://ingestionUri",
+                databaseName: "mockDB",
+                tableName: "mockTable",
+                applicationClientId: "clientId",
+                applicationSecret: "secret",
+                tenantId: "tenantId",
+                bufferBaseFileName: Path.Combine(bufferDir, "buffer"));
+
+            Assert.NotNull(sinkConfiguration);
+        }
+        finally
+        {
+            try { Directory.Delete(bufferDir, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void AzureDataExplorerSink_SystemManagedIdentity_Does_Not_Require_Secret_Or_Tenant()
+    {
+        var loggerConfiguration = new LoggerConfiguration();
+
+        var sinkConfiguration = loggerConfiguration.WriteTo.AzureDataExplorerSink(
+            ingestionUri: "http://ingestionUri",
+            databaseName: "mockDB",
+            tableName: "mockTable",
+            applicationClientId: "system",
+            isManagedIdentity: true);
+
+        Assert.NotNull(sinkConfiguration);
+    }
+
+    [Fact]
+    public void AzureDataExplorerSink_UserManagedIdentity_Does_Not_Require_Secret_Or_Tenant()
+    {
+        var loggerConfiguration = new LoggerConfiguration();
+
+        var sinkConfiguration = loggerConfiguration.WriteTo.AzureDataExplorerSink(
+            ingestionUri: "http://ingestionUri",
+            databaseName: "mockDB",
+            tableName: "mockTable",
+            applicationClientId: "11111111-1111-1111-1111-111111111111",
+            isManagedIdentity: true);
+
+        Assert.NotNull(sinkConfiguration);
+    }
+
+    [Fact]
+    public void AzureDataExplorerSink_WorkloadIdentity_Does_Not_Require_Any_Auth_Params()
+    {
+        var loggerConfiguration = new LoggerConfiguration();
+
+        var sinkConfiguration = loggerConfiguration.WriteTo.AzureDataExplorerSink(
+            ingestionUri: "http://ingestionUri",
+            databaseName: "mockDB",
+            tableName: "mockTable",
+            isWorkloadIdentity: true);
+
+        Assert.NotNull(sinkConfiguration);
+    }
+
+    [Fact]
+    public void AzureDataExplorerSink_UserToken_Does_Not_Require_Secret_Or_Tenant()
+    {
+        var loggerConfiguration = new LoggerConfiguration();
+
+        var sinkConfiguration = loggerConfiguration.WriteTo.AzureDataExplorerSink(
+            ingestionUri: "http://ingestionUri",
+            databaseName: "mockDB",
+            tableName: "mockTable",
+            userToken: "some-token");
+
+        Assert.NotNull(sinkConfiguration);
+    }
+
+    [Fact]
+    public void AzureDataExplorerSink_AadAppKey_Still_Requires_ApplicationSecret()
+    {
+        var loggerConfiguration = new LoggerConfiguration();
+
+        Assert.Throws<ArgumentNullException>(() =>
+            loggerConfiguration.WriteTo.AzureDataExplorerSink(
+                ingestionUri: "http://ingestionUri",
+                databaseName: "mockDB",
+                tableName: "mockTable",
+                applicationClientId: "clientId",
+                applicationSecret: null,
+                tenantId: "tenantId"));
+    }
+
+    [Fact]
+    public void AzureDataExplorerSink_AadAppKey_Still_Requires_TenantId()
+    {
+        var loggerConfiguration = new LoggerConfiguration();
+
+        Assert.Throws<ArgumentNullException>(() =>
+            loggerConfiguration.WriteTo.AzureDataExplorerSink(
+                ingestionUri: "http://ingestionUri",
+                databaseName: "mockDB",
+                tableName: "mockTable",
+                applicationClientId: "clientId",
+                applicationSecret: "secret",
+                tenantId: null));
+    }
+
+    [Fact]
+    public void AzureDataExplorerSink_AadAppKey_Still_Requires_ApplicationClientId()
+    {
+        var loggerConfiguration = new LoggerConfiguration();
+
+        Assert.Throws<ArgumentNullException>(() =>
+            loggerConfiguration.WriteTo.AzureDataExplorerSink(
+                ingestionUri: "http://ingestionUri",
+                databaseName: "mockDB",
+                tableName: "mockTable",
+                applicationClientId: null,
+                applicationSecret: "secret",
+                tenantId: "tenantId"));
+    }
+
+    [Fact]
+    public void AzureDataExplorerSink_ManagedIdentity_Requires_ApplicationClientId()
+    {
+        var loggerConfiguration = new LoggerConfiguration();
+
+        Assert.Throws<ArgumentNullException>(() =>
+            loggerConfiguration.WriteTo.AzureDataExplorerSink(
+                ingestionUri: "http://ingestionUri",
+                databaseName: "mockDB",
+                tableName: "mockTable",
+                applicationClientId: null,
+                isManagedIdentity: true));
+    }
 }

--- a/src/Serilog.Sinks.AzureDataExplorer.Tests/AzureDataExplorerSinkExtensionsTests.cs
+++ b/src/Serilog.Sinks.AzureDataExplorer.Tests/AzureDataExplorerSinkExtensionsTests.cs
@@ -256,4 +256,37 @@ public class AzureDataExplorerSinkExtensionsTests
                 isManagedIdentity: isManagedIdentity,
                 isWorkloadIdentity: isWorkloadIdentity));
     }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("\t")]
+    public void AzureDataExplorerSink_ManagedIdentity_Rejects_Whitespace_ApplicationClientId(string applicationClientId)
+    {
+        var loggerConfiguration = new LoggerConfiguration();
+
+        Assert.Throws<ArgumentNullException>(() =>
+            loggerConfiguration.WriteTo.AzureDataExplorerSink(
+                ingestionUri: "http://ingestionUri",
+                databaseName: "mockDB",
+                tableName: "mockTable",
+                applicationClientId: applicationClientId,
+                isManagedIdentity: true));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("\t")]
+    public void AzureDataExplorerSink_Whitespace_UserToken_Treated_As_No_Token(string userToken)
+    {
+        var loggerConfiguration = new LoggerConfiguration();
+
+        Assert.Throws<ArgumentNullException>(() =>
+            loggerConfiguration.WriteTo.AzureDataExplorerSink(
+                ingestionUri: "http://ingestionUri",
+                databaseName: "mockDB",
+                tableName: "mockTable",
+                userToken: userToken));
+    }
 }

--- a/src/Serilog.Sinks.AzureDataExplorer.Tests/appsettings.json
+++ b/src/Serilog.Sinks.AzureDataExplorer.Tests/appsettings.json
@@ -8,11 +8,7 @@
           "Args": {
             "ingestionUri": "%ingestionUri%",
             "databaseName": "%databaseName%",
-            "tableName": "NA",
-            "applicationClientId": "NA",
-            "applicationSecret": "NA",
-            "tenantId": "NA",
-            "userToken": "NA",
+            "tableName": "%tableName%",
             "batchPostingLimit": 10000,
             "period": 20,
             "queueSizeLimit": 100000

--- a/src/Serilog.Sinks.AzureDataExplorer.Tests/appsettings.xml
+++ b/src/Serilog.Sinks.AzureDataExplorer.Tests/appsettings.xml
@@ -11,13 +11,10 @@
         <Args>
         <ingestionUri>%ingestionUri%</ingestionUri>
         <databaseName>%databaseName%</databaseName>
-        <tableName>na</tableName>
+        <tableName>%tableName%</tableName>
         <batchPostingLimit>10</batchPostingLimit>
         <period>2</period>
         <queueSizeLimit>1000</queueSizeLimit>
-        <applicationClientId>na</applicationClientId>
-        <applicationSecret>na</applicationSecret>
-        <tenantId>na</tenantId>
         </Args>
       </Args>
     </WriteTo>

--- a/src/Serilog.Sinks.AzureDataExplorer/Extensions/AzureDataExplorerSinkExtensions.cs
+++ b/src/Serilog.Sinks.AzureDataExplorer/Extensions/AzureDataExplorerSinkExtensions.cs
@@ -95,17 +95,17 @@ namespace Serilog.Sinks.AzureDataExplorer.Extensions
             {
                 throw new ArgumentNullException(nameof(loggerConfiguration));
             }
-            if (ingestionUri == null)
+            if (string.IsNullOrWhiteSpace(ingestionUri))
             {
                 throw new ArgumentNullException(nameof(ingestionUri));
             }
 
-            if (databaseName == null)
+            if (string.IsNullOrWhiteSpace(databaseName))
             {
                 throw new ArgumentNullException(nameof(databaseName));
             }
 
-            if (tableName == null)
+            if (string.IsNullOrWhiteSpace(tableName))
             {
                 throw new ArgumentNullException(nameof(tableName));
             }
@@ -133,15 +133,15 @@ namespace Serilog.Sinks.AzureDataExplorer.Extensions
             }
             else if (!isWorkloadIdentity && userToken == null)
             {
-                if (applicationClientId == null)
+                if (string.IsNullOrWhiteSpace(applicationClientId))
                 {
                     throw new ArgumentNullException(nameof(applicationClientId));
                 }
-                if (applicationSecret == null)
+                if (string.IsNullOrWhiteSpace(applicationSecret))
                 {
                     throw new ArgumentNullException(nameof(applicationSecret));
                 }
-                if (tenantId == null)
+                if (string.IsNullOrWhiteSpace(tenantId))
                 {
                     throw new ArgumentNullException(nameof(tenantId));
                 }

--- a/src/Serilog.Sinks.AzureDataExplorer/Extensions/AzureDataExplorerSinkExtensions.cs
+++ b/src/Serilog.Sinks.AzureDataExplorer/Extensions/AzureDataExplorerSinkExtensions.cs
@@ -110,6 +110,17 @@ namespace Serilog.Sinks.AzureDataExplorer.Extensions
                 throw new ArgumentNullException(nameof(tableName));
             }
 
+            var explicitAuthModes =
+                (isManagedIdentity ? 1 : 0) +
+                (isWorkloadIdentity ? 1 : 0) +
+                (!string.IsNullOrEmpty(userToken) ? 1 : 0);
+
+            if (explicitAuthModes > 1)
+            {
+                throw new ArgumentException(
+                    "Only one authentication mode can be specified. Set at most one of isManagedIdentity, isWorkloadIdentity, or userToken.");
+            }
+
             if (isManagedIdentity)
             {
                 if (applicationClientId == null)

--- a/src/Serilog.Sinks.AzureDataExplorer/Extensions/AzureDataExplorerSinkExtensions.cs
+++ b/src/Serilog.Sinks.AzureDataExplorer/Extensions/AzureDataExplorerSinkExtensions.cs
@@ -70,10 +70,10 @@ namespace Serilog.Sinks.AzureDataExplorer.Extensions
             string ingestionUri,
             string databaseName,
             string tableName,
-            string applicationClientId,
-            string applicationSecret,
-            string tenantId,
-            string userToken = null, 
+            string applicationClientId = null,
+            string applicationSecret = null,
+            string tenantId = null,
+            string userToken = null,
             bool isManagedIdentity = false,
             bool isWorkloadIdentity = false,
             bool flushImmediately = true,
@@ -84,7 +84,7 @@ namespace Serilog.Sinks.AzureDataExplorer.Extensions
             string bufferFileOutputFormat =
                 "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] {Message:lj}{NewLine}{Exception}",
             bool useStreamingIngestion = false,
-            int batchPostingLimit = 1000, 
+            int batchPostingLimit = 1000,
             double period = 10,
             int queueSizeLimit = 100000,
 
@@ -110,19 +110,34 @@ namespace Serilog.Sinks.AzureDataExplorer.Extensions
                 throw new ArgumentNullException(nameof(tableName));
             }
 
-            if (applicationClientId == null)
+            if (isManagedIdentity)
             {
-                throw new ArgumentNullException(nameof(applicationClientId));
+                if (applicationClientId == null)
+                {
+                    throw new ArgumentNullException(nameof(applicationClientId),
+                        "applicationClientId is required when isManagedIdentity is true. Use \"system\" for system-assigned managed identity, or the client id of the user-assigned managed identity.");
+                }
             }
-
-            if (applicationSecret == null)
+            else if (isWorkloadIdentity)
             {
-                throw new ArgumentNullException(nameof(applicationSecret));
             }
-
-            if (tenantId == null)
+            else if (!string.IsNullOrEmpty(userToken))
             {
-                throw new ArgumentNullException(nameof(tenantId));
+            }
+            else
+            {
+                if (applicationClientId == null)
+                {
+                    throw new ArgumentNullException(nameof(applicationClientId));
+                }
+                if (applicationSecret == null)
+                {
+                    throw new ArgumentNullException(nameof(applicationSecret));
+                }
+                if (tenantId == null)
+                {
+                    throw new ArgumentNullException(nameof(tenantId));
+                }
             }
 
             AzureDataExplorerSinkOptions options = new AzureDataExplorerSinkOptions()
@@ -168,22 +183,7 @@ namespace Serilog.Sinks.AzureDataExplorer.Extensions
                 options = options.WithAadApplicationKey(applicationClientId: applicationClientId, applicationKey: applicationSecret, authority: tenantId);
             }
 
-
-            var batchingOptions = new BatchingOptions
-            {
-                BatchSizeLimit = options.BatchPostingLimit,
-                BufferingTimeLimit = options.Period,
-                EagerlyEmitFirstEvent = true,
-                QueueLimit = options.QueueSizeLimit
-            };
-
-
-            var azureDataExplorerSink = new AzureDataExplorerSink(options);
-
-            var sink = string.IsNullOrWhiteSpace(bufferBaseFileName) ? azureDataExplorerSink : (IBatchedLogEventSink) new AzureDataExplorerDurableSink(options);
-            return loggerConfiguration.Sink(sink, batchingOptions,
-                restrictedToMinimumLevel,
-                options.BufferFileLoggingLevelSwitch);
+            return loggerConfiguration.AzureDataExplorerSink(options, restrictedToMinimumLevel);
         }
     }
 }

--- a/src/Serilog.Sinks.AzureDataExplorer/Extensions/AzureDataExplorerSinkExtensions.cs
+++ b/src/Serilog.Sinks.AzureDataExplorer/Extensions/AzureDataExplorerSinkExtensions.cs
@@ -129,13 +129,7 @@ namespace Serilog.Sinks.AzureDataExplorer.Extensions
                         "applicationClientId is required when isManagedIdentity is true. Use \"system\" for system-assigned managed identity, or the client id of the user-assigned managed identity.");
                 }
             }
-            else if (isWorkloadIdentity)
-            {
-            }
-            else if (!string.IsNullOrEmpty(userToken))
-            {
-            }
-            else
+            else if (!isWorkloadIdentity && string.IsNullOrEmpty(userToken))
             {
                 if (applicationClientId == null)
                 {

--- a/src/Serilog.Sinks.AzureDataExplorer/Extensions/AzureDataExplorerSinkExtensions.cs
+++ b/src/Serilog.Sinks.AzureDataExplorer/Extensions/AzureDataExplorerSinkExtensions.cs
@@ -110,10 +110,12 @@ namespace Serilog.Sinks.AzureDataExplorer.Extensions
                 throw new ArgumentNullException(nameof(tableName));
             }
 
+            userToken = string.IsNullOrWhiteSpace(userToken) ? null : userToken;
+
             var explicitAuthModes =
                 (isManagedIdentity ? 1 : 0) +
                 (isWorkloadIdentity ? 1 : 0) +
-                (!string.IsNullOrEmpty(userToken) ? 1 : 0);
+                (userToken != null ? 1 : 0);
 
             if (explicitAuthModes > 1)
             {
@@ -123,13 +125,13 @@ namespace Serilog.Sinks.AzureDataExplorer.Extensions
 
             if (isManagedIdentity)
             {
-                if (applicationClientId == null)
+                if (string.IsNullOrWhiteSpace(applicationClientId))
                 {
                     throw new ArgumentNullException(nameof(applicationClientId),
                         "applicationClientId is required when isManagedIdentity is true. Use \"system\" for system-assigned managed identity, or the client id of the user-assigned managed identity.");
                 }
             }
-            else if (!isWorkloadIdentity && string.IsNullOrEmpty(userToken))
+            else if (!isWorkloadIdentity && userToken == null)
             {
                 if (applicationClientId == null)
                 {
@@ -179,7 +181,7 @@ namespace Serilog.Sinks.AzureDataExplorer.Extensions
             {
                 options = options.WithWorkloadIdentity();
             }
-            else if (!string.IsNullOrEmpty(userToken))
+            else if (userToken != null)
             {
                 options = options.WithAadUserToken(userToken: userToken);
             }


### PR DESCRIPTION
Closes #46
Closes #47

## Problem

The string-parameter `AzureDataExplorerSink` overload in `AzureDataExplorerSinkExtensions.cs` had two bugs:

1. **#46 — InvalidCastException in durable mode.** Setting `bufferBaseFileName` triggered`(IBatchedLogEventSink) new AzureDataExplorerDurableSink(options)`, but `AzureDataExplorerDurableSink` only implements `ILogEventSink`.The cast threw at runtime, making durable mode unusable through this overload (and through Serilog appsettings binding, which uses it).

2. **#47 — over-strict credential validation.** `applicationClientId`, `applicationSecret`, and `tenantId` were null-checked unconditionally at the top of the method, so callers using managed identity, workload identity, or a user token had to pass non-null dummies for credentials their auth mode never consumed.

## Fix

* Made `applicationClientId`, `applicationSecret`, `tenantId` optional (`= null` defaults). Source- and binary-compatible.
* Replaced the blanket null checks with auth-mode-aware validation
* Removed the broken cast and the duplicate batching/sink-construction block. The convenience overload now builds the options object and delegates to the existing options-based overload, which already has correct durable-vs-batched wiring. Behaviour for the non-durable path is byte-for-byte identical (same `BatchingOptions`, same `Sink(...)`  call)

## Tests

10 new regression tests in `AzureDataExplorerSinkExtensionsTests.cs` cover both bugs across all four auth modes, durable mode on both overloads, and the preserved AAD-app-key null checks.
